### PR TITLE
Fix build script

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set +e
 git submodule update --init --recursive
 pushd wallet-wasm


### PR DESCRIPTION
Current build script is not working for me. I'm getting the following error:

```bash
$ ./build 
./build: 4: ./build: pushd: not found
error: could not find `Cargo.toml` in `/home/Projects/iohk/icarus-poc/js-cardano-wasm` or any parent directory
./build: 6: ./build: popd: not found
```

It seems to be related to the [following issue](https://stackoverflow.com/questions/5193048/bin-sh-pushd-not-found). I fixed it changing the shell to bash.