### PR TITLE
Use local webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Cardano crypto from rust-wasm binding",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "webpack",
+    "build": "./node_modules/webpack/bin/webpack.js",
     "test": "mocha js/tests",
     "build-and-test": "npm run build && npm run test",
     "test-watch": "nodemon --watch js --exec npm run build-and-test",


### PR DESCRIPTION
To make it easier to build, we could use local webpack binary as it's already installed as dependency