### PR TITLE
return the details of the transaction when creating a ready to send tx

### DIFF
--- a/js/Wallet.js
+++ b/js/Wallet.js
@@ -102,7 +102,10 @@ export const generateAddresses = (module, wallet, account, type, indices) => {
  * let fee_addr = "DdzFFzCqrhtCUjHyzgvgigwA5soBgDxpc8WfnG1RGhrsRrWMV8uKdpgVfCXGgNuXhdN4qxPMvRUtbUnWhPzxSdxJrWzPqACZeh6scCH5";
  * let change_addr = "DdzFFzCqrhtCUjHyzgvgigwA5soBgDxpc8WfnG1RGhrsRrWMV8uKdpgVfCXGgNuXhdN4qxPMvRUtbUnWhPzxSdxJrWzPqACZeh6scCH5";
  *
- * let signed_tx = CardanoCrypto.Wallet.spend(wallet, inputs, outputs, fee_addr, change_addr).result;
+ * let result = CardanoCrypto.Wallet.spend(wallet, inputs, outputs, fee_addr, change_addr).result;
+ *
+ * console.log("details of the transaction: ", result.tx);
+ * console.log("bytes array (encoded tx): ", result.cbor_encoded_tx);
  * ```
  *
  * @param module - the WASM module that is used for crypto operations


### PR DESCRIPTION
now, instead of returning only the cbor encoded transaction and witnesses, it also returns the transaction and witnesses.

```
> JSON.stringify(result.tx.tx, null, 4);
"{
    "inputs": [
        {
            "id": "1c7b178c1655628ca87c7da6a5d9d13c1e0a304094ac88770768d565e3d20e0b",
            "index": 42
        }
    ],
    "outputs": [
        {
            "address": "DdzFFzCqrhtCUjHyzgvgigwA5soBgDxpc8WfnG1RGhrsRrWMV8uKdpgVfCXGgNuXhdN4qxPMvRUtbUnWhPzxSdxJrWzPqACZeh6scCH5",
            "value": 666
        },
        {
            "address": "DdzFFzCqrhtCUjHyzgvgigwA5soBgDxpc8WfnG1RGhrsRrWMV8uKdpgVfCXGgNuXhdN4qxPMvRUtbUnWhPzxSdxJrWzPqACZeh6scCH5",
            "value": 166719
        },
        {
            "address": "DdzFFzCqrhtCUjHyzgvgigwA5soBgDxpc8WfnG1RGhrsRrWMV8uKdpgVfCXGgNuXhdN4qxPMvRUtbUnWhPzxSdxJrWzPqACZeh6scCH5",
            "value": 92669963
        }
    ]
}"
```
