### PR TITLE
No feeaddr in wallet spend's API

### DIFF
--- a/js-example/src/Components/Bindings/BIP39.js
+++ b/js-example/src/Components/Bindings/BIP39.js
@@ -9,7 +9,7 @@ exports.generateMnemonicImpl = function() {
 
 exports.mnemonicToSeedImpl = function (m) {
     try {
-        var e = bip39.mnemonicToEntropy(m);
+        var e = Buffer.from(bip39.mnemonicToEntropy(m), 'hex');
         return window.CardanoCrypto.Blake2b.blake2b_256(e);
     } catch(e) {
         console.error("BIP39 mnemonicToSeed error:", e);

--- a/js/Wallet.js
+++ b/js/Wallet.js
@@ -99,12 +99,12 @@ export const generateAddresses = (module, wallet, account, type, indices) => {
  *     ];
  *
  * // where the fee will need to be sent
- * let fee_addr = "DdzFFzCqrhtCUjHyzgvgigwA5soBgDxpc8WfnG1RGhrsRrWMV8uKdpgVfCXGgNuXhdN4qxPMvRUtbUnWhPzxSdxJrWzPqACZeh6scCH5";
  * let change_addr = "DdzFFzCqrhtCUjHyzgvgigwA5soBgDxpc8WfnG1RGhrsRrWMV8uKdpgVfCXGgNuXhdN4qxPMvRUtbUnWhPzxSdxJrWzPqACZeh6scCH5";
  *
- * let result = CardanoCrypto.Wallet.spend(wallet, inputs, outputs, fee_addr, change_addr).result;
+ * let result = CardanoCrypto.Wallet.spend(wallet, inputs, outputs, change_addr).result;
  *
  * console.log("details of the transaction: ", result.tx);
+ * console.log("fees of the transaction: ", result.fee);
  * console.log("bytes array (encoded tx): ", result.cbor_encoded_tx);
  * ```
  *
@@ -112,15 +112,13 @@ export const generateAddresses = (module, wallet, account, type, indices) => {
  * @param wallet - The wallet object as created by the `fromSeed` function
  * @param inputs - the list of inputs
  * @param outputs - the list of payment to make
- * @param fee_addr - the address to send the fee to
  * @param change_addr - the address to send the change to
- * @returns {*}  - a ready to use, signed transaction encoded in cbor
+ * @returns {*}  - a ready to use, signed transaction encoded in cbor, the fee computed and the JSON encoded version of the TxAux.
  */
-export const spend = (module, wallet, inputs, outputs, fee_addr, change_addr) => {
+export const spend = (module, wallet, inputs, outputs, change_addr) => {
     const input = { wallet: wallet
                   , inputs: inputs
                   , outputs: outputs
-                  , fee_addr: fee_addr
                   , change_addr: change_addr
                   };
     const input_str = JSON.stringify(input);

--- a/wallet-wasm/src/lib.rs
+++ b/wallet-wasm/src/lib.rs
@@ -517,7 +517,6 @@ struct WalletSpendInput {
     wallet: Wallet,
     inputs: tx::Inputs,
     outputs: tx::Outputs,
-    fee_addr: address::ExtendedAddr,
     change_addr: address::ExtendedAddr
 }
 
@@ -530,7 +529,7 @@ struct WalletSpendOutput {
 #[no_mangle]
 pub extern "C" fn xwallet_spend(input_ptr: *const c_uchar, input_sz: usize, output_ptr: *mut c_uchar) -> i32 {
     let input : WalletSpendInput = input_json!(output_ptr, input_ptr, input_sz);
-    let txaux = jrpc_try!(output_ptr, input.wallet.new_transaction(&input.inputs, &input.outputs, &input.fee_addr, &input.change_addr));
+    let txaux = jrpc_try!(output_ptr, input.wallet.new_transaction(&input.inputs, &input.outputs, &input.change_addr));
     let cbor = jrpc_try!(output_ptr, cbor::encode_to_cbor(&txaux));
     jrpc_ok!(
         output_ptr,


### PR DESCRIPTION
- [x] update rust-cardano-crypto to latest version;
- [x] remove the fee addr from the `Wallet.spend` API;
- [x] little fix in the js-example code.