### PR TITLE
Fail if toolchain is not installed

### DIFF
--- a/build
+++ b/build
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-RUST_TOOLCHAIN=$(cat rust-toolchain)
+RUST_TOOLCHAIN="$(cat rust-toolchain)"
 
 set +e
 git submodule update --init --recursive
 pushd wallet-wasm
-rustup target add --toolchain ${RUST_TOOLCHAIN} wasm32-unknown-unknown
-cargo  +${RUST_TOOLCHAIN} build --target wasm32-unknown-unknown --release --verbose
-popd
+rustup target add --toolchain ${RUST_TOOLCHAIN} wasm32-unknown-unknown && \
+cargo  +${RUST_TOOLCHAIN} build --target wasm32-unknown-unknown --release --verbose && \
+popd && \
 npm run build


### PR DESCRIPTION
This returns an error if `rustup` or `cargo` invocation fails
