### PR TITLE
Update rust cardano

### DIFF
--- a/js/PaperWallet.js
+++ b/js/PaperWallet.js
@@ -24,7 +24,7 @@ export const scramble = (module, iv, password, input) => {
 /**
  * A sugar method on top of `scramble` that expects string params.
  * @param module - the WASM module that is used for crypto operations
- * @param iv: Uint8Array - 4 random bytes of entropy
+ * @param iv: Uint8Array - 8 random bytes of entropy
  * @param password: string
  * @param mnenomics: string (12 word mnemonics which should be scrambled))
  * @returns {*} - the scrambled 15 words

--- a/wallet-wasm/Cargo.lock
+++ b/wallet-wasm/Cargo.lock
@@ -2,19 +2,21 @@
 name = "cardano"
 version = "0.1.0"
 dependencies = [
- "cbor_event 0.1.0",
- "cryptoxide 0.1.0",
+ "cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cryptoxide 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cbor_event"
-version = "0.1.0"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cryptoxide"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dtoa"
@@ -87,14 +89,16 @@ name = "wallet-wasm"
 version = "0.1.0"
 dependencies = [
  "cardano 0.1.0",
- "cbor_event 0.1.0",
- "cryptoxide 0.1.0",
+ "cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cryptoxide 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
+"checksum cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29a95a1de12d1f5a3ff0c34cd2578f625a5feddb5d5672546ebbbecdb6287a0f"
+"checksum cryptoxide 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc9be687df90da186ed5c6ada0b6b4d69f5ad914071870bc5d41277377d30427"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
 "checksum proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6"

--- a/wallet-wasm/Cargo.toml
+++ b/wallet-wasm/Cargo.toml
@@ -12,9 +12,12 @@ keywords = [ "Cardano", "Wallet", "Wasm" ]
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-cryptoxide = { path = "../rust/cryptoxide" }
-cbor_event = { path = "../rust/cbor_event" }
-cardano    = { path = "../rust/cardano" }
+cryptoxide = "0.1"
+cbor_event = "1.0"
+
+[dependencies.cardano]
+path = "../rust/cardano"
+features = [ "generic-serialization" ]
 
 [lib]
 crate-type = ["cdylib"]

--- a/wallet-wasm/src/lib.rs
+++ b/wallet-wasm/src/lib.rs
@@ -18,10 +18,12 @@ use self::cardano::hdwallet;
 use self::cardano::paperwallet;
 use self::cardano::address;
 use self::cardano::hdpayload;
-use self::cardano::{util::{hex}, tx, fee, coin, hash::{HASH_SIZE}, txutils};
+use self::cardano::{util::{hex}, tx, fee, input_selection, coin, txutils};
 use self::cardano::config::{Config};
 use self::cardano::wallet::{self, bip44, rindex, scheme::{Wallet}};
 use self::cardano::bip::{bip39};
+
+use self::cardano::util::try_from_slice::{TryFromSlice};
 
 use std::{mem, result, string, convert, fmt};
 use std::ffi::{CStr, CString};
@@ -250,7 +252,7 @@ pub extern "C" fn wallet_public_to_address(xpub_ptr: *const c_uchar, payload_ptr
     let attrs = address::Attributes::new_bootstrap_era(Some(hdap));
     let ea = address::ExtendedAddr::new(addr_type, sd, attrs);
 
-    let ea_bytes = ea.to_bytes();
+    let ea_bytes = cbor!(ea).unwrap();
 
     unsafe { write_data(&ea_bytes, out) }
 
@@ -260,7 +262,7 @@ pub extern "C" fn wallet_public_to_address(xpub_ptr: *const c_uchar, payload_ptr
 #[no_mangle]
 pub extern "C" fn wallet_address_get_payload(addr_ptr: *const c_uchar, addr_sz: usize, out: *mut c_uchar) -> u32 {
     let addr_bytes = unsafe { read_data(addr_ptr, addr_sz) };
-    match address::ExtendedAddr::from_bytes(&addr_bytes).ok() {
+    match address::ExtendedAddr::try_from_slice(&addr_bytes).ok() {
         None => (-1i32) as u32,
         Some(r)  => {
             match r.attributes.derivation_path {
@@ -315,11 +317,11 @@ pub extern "C" fn wallet_payload_decrypt(key_ptr: *const c_uchar, payload_ptr: *
 
 #[no_mangle]
 pub extern "C" fn wallet_txin_create(txid_ptr: *const c_uchar, index: u32, out: *mut c_uchar) -> u32 {
-    let txid_bytes = unsafe { read_data(txid_ptr, HASH_SIZE) };
+    let txid_bytes = unsafe { read_data(txid_ptr, tx::TxId::HASH_SIZE) };
 
-    let txid = tx::TxId::from_slice(&txid_bytes).unwrap();
+    let txid = tx::TxId::try_from_slice(&txid_bytes).unwrap();
 
-    let txin = tx::TxIn::new(txid, index);
+    let txin = tx::TxoPointer::new(txid, index);
     let out_buf = cbor!(&txin).unwrap();
 
     unsafe { write_data(&out_buf, out) }
@@ -330,7 +332,7 @@ pub extern "C" fn wallet_txin_create(txid_ptr: *const c_uchar, index: u32, out: 
 pub extern "C" fn wallet_txout_create(ea_ptr: *const c_uchar, ea_sz: usize, amount: u32, out: *mut c_uchar) -> u32 {
     let ea_bytes = unsafe { read_data(ea_ptr, ea_sz) };
 
-    let ea = address::ExtendedAddr::from_bytes(&ea_bytes).unwrap();
+    let ea = address::ExtendedAddr::try_from_slice(&ea_bytes).unwrap();
     let coin = coin::Coin::new(amount as u64).unwrap();
 
     let txout = tx::TxOut::new(ea, coin);
@@ -548,7 +550,7 @@ pub struct Bip44Wallet {
     root_cached_key: hdwallet::XPrv,
 
     config: Config,
-    selection_policy: fee::SelectionPolicy,
+    selection_policy: input_selection::SelectionPolicy,
     derivation_scheme: hdwallet::DerivationScheme,
 }
 impl Bip44Wallet {
@@ -566,7 +568,7 @@ pub extern "C" fn xwallet_create(input_ptr: *const c_uchar, input_sz: usize, out
     let seed = input_json!(output_ptr, input_ptr, input_sz);
 
     let derivation_scheme = hdwallet::DerivationScheme::V2;
-    let selection_policy = fee::SelectionPolicy::FirstMatchFirst;
+    let selection_policy = input_selection::SelectionPolicy::FirstMatchFirst;
     let config = Config::default();
 
     let xprv = hdwallet::XPrv::generate_from_seed(&seed);
@@ -589,7 +591,7 @@ pub extern "C" fn xwallet_from_master_key(input_ptr: *const c_uchar, output_ptr:
     let xprv = unsafe { read_xprv(input_ptr) };
 
     let derivation_scheme = hdwallet::DerivationScheme::V2;
-    let selection_policy = fee::SelectionPolicy::FirstMatchFirst;
+    let selection_policy = input_selection::SelectionPolicy::FirstMatchFirst;
     let config = Config::default();
 
     let bip44_wallet = bip44::Wallet::from_root_key(xprv, derivation_scheme);
@@ -611,7 +613,7 @@ pub struct DaedalusWallet {
     root_cached_key: hdwallet::XPrv,
 
     config: Config,
-    selection_policy: fee::SelectionPolicy,
+    selection_policy: input_selection::SelectionPolicy,
     derivation_scheme: hdwallet::DerivationScheme,
 }
 impl DaedalusWallet {
@@ -629,7 +631,7 @@ pub extern "C" fn xwallet_create_daedalus_mnemonic(input_ptr: *const c_uchar, in
     let mnemonics_phrase : String = input_json!(output_ptr, input_ptr, input_sz);
 
     let derivation_scheme = hdwallet::DerivationScheme::V1;
-    let selection_policy = fee::SelectionPolicy::FirstMatchFirst;
+    let selection_policy = input_selection::SelectionPolicy::FirstMatchFirst;
     let config = Config::default();
 
     let daedalus_wallet = jrpc_try!(output_ptr, rindex::Wallet::from_daedalus_mnemonics(
@@ -711,8 +713,8 @@ pub struct TxIn {
     index: u32
 }
 impl TxIn {
-    fn convert(&self) -> tx::TxIn {
-        tx::TxIn {
+    fn convert(&self) -> tx::TxoPointer {
+        tx::TxoPointer {
             id: self.id,
             index: self.index
         }
@@ -793,11 +795,11 @@ pub struct TxInInfo {
     pub addressing: [u32;2]
 }
 impl TxInInfo {
-    fn convert(&self) -> txutils::TxInInfo<<rindex::Wallet as Wallet>::Addressing> {
-        txutils::TxInInfo {
+    fn convert(&self) -> txutils::TxoPointerInfo<<rindex::Wallet as Wallet>::Addressing> {
+        txutils::TxoPointerInfo {
             txin: self.ptr.convert(),
             value: self.value.0,
-            address_identified: (self.addressing[0], self.addressing[1])
+            address_identified: rindex::Addressing::new(self.addressing[0], self.addressing[1])
         }
     }
 }
@@ -809,7 +811,7 @@ struct WalletMoveInput {
     output: address::ExtendedAddr
 }
 impl WalletMoveInput {
-    fn get_inputs(&self) -> Vec<txutils::TxInInfo<<rindex::Wallet as Wallet>::Addressing>> {
+    fn get_inputs(&self) -> Vec<txutils::TxoPointerInfo<<rindex::Wallet as Wallet>::Addressing>> {
         self.inputs.iter().map(|i| i.convert()).collect()
     }
 }


### PR DESCRIPTION
## New changes

fix #30 

## Changes from Rust SDK

input-output-hk/rust-cardano#278 from input-output-hk/update-input-selection-algorithm
    
    Fix bad input selection in some rare cases

--
input-output-hk/rust-cardano#276 from nahern/patch-1
    
    Update README.md

--
input-output-hk/rust-cardano#274 from input-output-hk/directory-name
    
    add concept of a DirectoryName in the storage units

--
input-output-hk/rust-cardano#273 from input-output-hk/rindex-error-handlings
    
    Update random index's Error handling

--
input-output-hk/rust-cardano#272 from edolstra/verify-utxos
    
    Add utxo verification

--
input-output-hk/rust-cardano#271 from infinityblockchainlabs/calculate-transaction-fee
    
    Calculate transaction fee

--
input-output-hk/rust-cardano#267 from edolstra/stream-blocks
    
    Use the block streaming API for synchronization

--
input-output-hk/rust-cardano#270 from input-output-hk/error-handling
    
    add missing error handling on rindex style wallet

--
input-output-hk/rust-cardano#268 from input-output-hk/fix-packfile-reader
    
    remove Reader::From and make sure everyone check the magic and version

--
input-output-hk/rust-cardano#247 from edolstra/verify-chain
    
    Add function for verifying blocks in the context of the chain

--
input-output-hk/rust-cardano#266 from input-output-hk/prevent-non-hardened-derivation
    
    avoid construction of the Addressing for random index

--
input-output-hk/rust-cardano#265 from input-output-hk/hdpayload-golden-tests
    
    add hdpayload golden tests

--
input-output-hk/rust-cardano#264 from input-output-hk/remove_cryptoxide
    
    Remove cryptoxide

--
input-output-hk/rust-cardano#263 from input-output-hk/remove_cbor_event
    
    remove cbor_event from rust-cardano repository

--
input-output-hk/rust-cardano#262 from input-output-hk/fix-authors
    
    fix authors in Cargo.toml

--
input-output-hk/rust-cardano#261 from input-output-hk/storage-split
    
    split storage into 2

--
input-output-hk/rust-cardano#260 from input-output-hk/error-handlings
    
    Error handling improvements

--
input-output-hk/rust-cardano#259 from input-output-hk/doc-short
    
    doc and licensing

--
input-output-hk/rust-cardano#258 from input-output-hk/tx-builder-auto-output
    
    tx builder auto output, documentation and tests

--
input-output-hk/rust-cardano#257 from input-output-hk/error-handlings
    
    Improves support for Error and Error handling in the cardano crate

--
input-output-hk/rust-cardano#256 from input-output-hk/serde-optional
    
    make serde derivation optional in cardano crate

--
input-output-hk/rust-cardano#255 from input-output-hk/tx-building
    
    Tx building

--
input-output-hk/rust-cardano#254 from input-output-hk/add-try-from-slice
    
    Add TryFromSlice in the cardano::util module

--
input-output-hk/rust-cardano#250 from input-output-hk/c-exports
    
    improvements to C-API

--
input-output-hk/rust-cardano#252 from edolstra/fix-246
    
    Fix #246

--
input-output-hk/rust-cardano#249 from input-output-hk/storage-errors-cleanup
    
    Storage errors cleanup

--
input-output-hk/rust-cardano#240 from input-output-hk/move-cli-and-doc
    
    Move cli to cardano-cli

--
input-output-hk/rust-cardano#234 from edolstra/versioned-files
    
     Add magic + version number to all binary files

--
input-output-hk/rust-cardano#236 from input-output-hk/add-new-line
    
    fix missing new line

--
input-output-hk/rust-cardano#229 from input-output-hk/transaction-cli
    
    CLI: transaction support

--
input-output-hk/rust-cardano#232 from edolstra/verify-block
    
    Implement block consistency verification

--
input-output-hk/rust-cardano#231 from input-output-hk/blockchain-log
    
    Add blockchain log

--
input-output-hk/rust-cardano#228 from input-output-hk/list-wallets
    
    add command to list wallets

--
input-output-hk/rust-cardano#224 from input-output-hk/storage-cleanup
    
    Storage cleanup

--
input-output-hk/rust-cardano#227 from input-output-hk/improved-cat
    
    Improve pretty printed style of the different object in the terminal

--
input-output-hk/rust-cardano#225 from input-output-hk/improved-mnemonics-prompt
    
    improved mnemonics prompt

--
input-output-hk/rust-cardano#223 from input-output-hk/log-and-status-update
    
    improve wallet log display

--
input-output-hk/rust-cardano#222 from input-output-hk/command-list-blockchains
    
    add blockchain list command

--
input-output-hk/rust-cardano#221 from input-output-hk/add-command-to-destroy-blockchain
    
    Add command to destroy blockchain

--
input-output-hk/rust-cardano#220 from input-output-hk/add-command-to-destroy-wallet
    
    Add command to destroy wallet

--
input-output-hk/rust-cardano#216 from input-output-hk/block-improvements
    
    Block improvements

--
input-output-hk/rust-cardano#214 from input-output-hk/improve-password-prompts
    
    improve password prompt

--
input-output-hk/rust-cardano#210 from edolstra/send-tx
    
    Transaction sending support

--
input-output-hk/rust-cardano#212 from input-output-hk/fix-some-blockchain-issue
    
    add support for testnet and staging

--
input-output-hk/rust-cardano#211 from input-output-hk/fix-some-ux-console-issue
    
    Fix some ux console issue

--
input-output-hk/rust-cardano#208 from input-output-hk/wallet-status
    
    add status and log wallet

--
input-output-hk/rust-cardano#203 from jleni/master
    
    Appveyor CI

--
input-output-hk/rust-cardano#207 from input-output-hk/wallet-recover-and-sync
    
    Wallet recover and sync

--
input-output-hk/rust-cardano#206 from input-output-hk/remove-wallet-cli
    
    Remove wallet cli

--
input-output-hk/rust-cardano#205 from input-output-hk/coin-conversion
    
    Coin conversion

--
input-output-hk/rust-cardano#204 from edolstra/subscription
    
    Use the subscription mechanism to receive tip updates from the server

