### PR TITLE
Add size optimalization

### DIFF
--- a/wallet-wasm/Cargo.toml
+++ b/wallet-wasm/Cargo.toml
@@ -21,3 +21,8 @@ features = [ "generic-serialization" ]
 
 [lib]
 crate-type = ["cdylib"]
+
+[profile.release]
+debug = false
+lto = true
+opt-level = 's'


### PR DESCRIPTION
Added code size optimalization based on:
https://rustwasm.github.io/book/game-of-life/code-size.html

it should go from:
```
              Asset     Size  Chunks                    Chunk Names
    ./dist/index.js  8.51 MB       0  [emitted]  [big]  index
./dist/index.js.map  8.63 MB       0  [emitted]         index
```

to:

```
              Asset     Size  Chunks                    Chunk Names
    ./dist/index.js  2.38 MB       0  [emitted]  [big]  index
./dist/index.js.map   2.5 MB       0  [emitted]         index
```
