### PR TITLE
Allows compilation to Rust Lib

### DIFF
--- a/wallet-wasm/Cargo.toml
+++ b/wallet-wasm/Cargo.toml
@@ -20,7 +20,7 @@ path = "../rust/cardano"
 features = [ "generic-serialization" ]
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 
 [profile.release]
 debug = false


### PR DESCRIPTION
In Emurgo we are working in libraries to implement the c-bindings for iOS and Android. Instead of copy-pasting the code from this repo, it would be awesome if we could reuse it by adding this repo as a `git submodule` :). This change allows the compilation to a rust lib.