### PR TITLE
Restore Cargo.toml to previous configuration

### DIFF
--- a/wallet-wasm/Cargo.toml
+++ b/wallet-wasm/Cargo.toml
@@ -20,7 +20,7 @@ path = "../rust/cardano"
 features = [ "generic-serialization" ]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["cdylib"]
 
 [profile.release]
 debug = false


### PR DESCRIPTION
There is a problem when adding lib because it disables lto for cdylib :( https://github.com/rust-lang/cargo/issues/2301
sorry about that 🙈