### PR TITLE
Replaced erroneous comma with a colon 

### DIFF
--- a/js/Wallet.js
+++ b/js/Wallet.js
@@ -131,7 +131,7 @@ export const newAccount = (module, wallet, account) => {
  * @returns {*}  - a list of ready to use addresses
  */
 export const generateAddresses = (module, account, type, indices) => {
-    const input = { account,
+    const input = { account: account
                   , address_type: type
                   , indices: indices
                   };

--- a/js/Wallet.js
+++ b/js/Wallet.js
@@ -131,7 +131,7 @@ export const newAccount = (module, wallet, account) => {
  * @returns {*}  - a list of ready to use addresses
  */
 export const generateAddresses = (module, account, type, indices) => {
-    const input = { account, account
+    const input = { account,
                   , address_type: type
                   , indices: indices
                   };


### PR DESCRIPTION
Account var is duplicating in object declaration like `{ account, account }`, it constantly gets highlighted in my IDE as error, and I always forget to propose a fix )