### PR TITLE
Generate input-tx and address by redemption public key

### DIFF
--- a/js/Redemption.js
+++ b/js/Redemption.js
@@ -4,6 +4,7 @@ import { newArray, newArray0, copyArray } from './utils/arrays';
 import { apply } from './utils/functions';
 
 export const REDEMPTION_PRIVATE_KEY_SIZE = 32;
+export const REDEMPTION_PUBLIC_KEY_SIZE = 32;
 const MAX_OUTPUT_SIZE = 4096;
 
 /**
@@ -23,6 +24,26 @@ export const redemptionKeyToAddress = (module, redemptionKey, magic) => {
     module.dealloc(bufkey);
     module.dealloc(bufaddr);
     return result;
+};
+
+/**
+ * @param module           - the WASM module that is used for crypto operations
+ * @param redemptionPubKey - the public redemption key, needs to be {@link REDEMPTION_PUBLIC_KEY_SIZE}
+ * @param magic            - protocol magic integer
+ * @returns {*}            - returns false if the seed is not of the valid length, or returns the response as: { tx_id, address }
+ */
+export const redemptionPubKeyToAvvmTxOut = (module, redemptionPubKey, magic) => {
+    if (redemptionKey.length !== REDEMPTION_PRIVATE_KEY_SIZE) {
+        return false;
+    }
+    const bufkey = newArray(module, redemptionKey);
+    const bufoutput = newArray0(module, MAX_OUTPUT_SIZE);
+    const rsz = module.redemption_public_to_avvm_tx_out(bufkey, magic, bufoutput);
+    let output_array = copyArray(module, bufoutput, rsz);
+    module.dealloc(bufkey);
+    module.dealloc(bufoutput);
+    let output_str = iconv.decode(Buffer.from(output_array), 'utf8');
+    return JSON.parse(output_str);
 };
 
 /**

--- a/js/Redemption.js
+++ b/js/Redemption.js
@@ -33,10 +33,10 @@ export const redemptionKeyToAddress = (module, redemptionKey, magic) => {
  * @returns {*}            - returns false if the seed is not of the valid length, or returns the response as: { tx_id, address }
  */
 export const redemptionPubKeyToAvvmTxOut = (module, redemptionPubKey, magic) => {
-    if (redemptionKey.length !== REDEMPTION_PRIVATE_KEY_SIZE) {
+    if (redemptionPubKey.length !== REDEMPTION_PUBLIC_KEY_SIZE) {
         return false;
     }
-    const bufkey = newArray(module, redemptionKey);
+    const bufkey = newArray(module, redemptionPubKey);
     const bufoutput = newArray0(module, MAX_OUTPUT_SIZE);
     const rsz = module.redemption_public_to_avvm_tx_out(bufkey, magic, bufoutput);
     let output_array = copyArray(module, bufoutput, rsz);
@@ -79,5 +79,6 @@ export const createRedemptionTransaction = (module, redemptionKey, input, output
 
 export default {
     redemptionKeyToAddress: apply(redemptionKeyToAddress, RustModule),
+    redemptionPubKeyToAvvmTxOut: apply(redemptionPubKeyToAvvmTxOut, RustModule),
     createRedemptionTransaction: apply(createRedemptionTransaction, RustModule),
 };

--- a/js/tests/redemption.js
+++ b/js/tests/redemption.js
@@ -25,13 +25,18 @@ let mkTest = (i) => {
             await CardanoCrypto.loadRustModule()
         });
 
-        it('generates valid address', function() {
+        it('generates valid avvm tx from public', function () {
+          const a = CardanoCrypto.Redemption.redemptionPubKeyToAvvmTxOut('URVk8FxX6Ik9z-Cub09oOxMkp6FwNq27kJUXbjJnfsQ=', cfg.protocol_magic);
+          console.log(a);
+        });
+
+        it('generates valid address from private', function() {
           const a = CardanoCrypto.Redemption.redemptionKeyToAddress(redemptionKey, cfg.protocol_magic);
           const [tagged, checksum] = cbor.decode(Buffer.from(a));
           expect(crc.crc32(tagged.value)).equal(checksum);
         });
 
-        it('creates address matching expected', function() {
+        it('creates address from private matching expected', function() {
           const a = CardanoCrypto.Redemption.redemptionKeyToAddress(redemptionKey, cfg.protocol_magic);
           expect(bs58.encode(Buffer.from(a))).equal(expectedAddress)
         });

--- a/js/tests/redemption.js
+++ b/js/tests/redemption.js
@@ -6,10 +6,13 @@ const crc = require('crc');
 
 const TEST_VECTORS = [
   {
+    iohkRedemptionPubKey: 'URVk8FxX6Ik9z-Cub09oOxMkp6FwNq27kJUXbjJnfsQ=',
+    expectedIohkRedemptionAddress: 'Ae2tdPwUPEZKQuZh2UndEoTKEakMYHGNjJVYmNZgJk2qqgHouxDsA5oT83n',
+    expectedIohkRedemptionInputTx: '0ae3da29711600e94a33fb7441d2e76876a9a1e98b5ebdefbf2e3bc535617616',
     redemptionKey: Buffer.from('qXQWDxI3JrlFRtC4SeQjeGzLbVXWBomYPbNO1Vfm1T4=', 'base64'),
-    expectedAddress: 'Ae2tdPwUPEZ1xZTLczMGYL5PhADi1nbFmESqS9vUuLkyUe1isQ77TRUE9NS',
-    expectedPublicKey: 'faf8ed5be127c8ea22e3a0f1b9335f910aaa672e96c41d7cbdcaed897a450667',
-    expectedSignature: '80ed81b9f3683684fdb7c286eb7cfa63580a239ed6bf67f71643d290de2206855171003c7f33cad04e9fa28ee5d5c18c4e5f0d788ae2a63fa492ba7b59995c03',
+    expectedAddress: 'Ae2tdPwUPEZB9sRkyXbcVMNa4pwFzzmxP4WkX88bMduUgusn26UzCtyCr42',
+    expectedPublicKey: '5a67cee38877909eab7d19de36cb8537bb102d9952d107ced2bfedfd823b0d34',
+    expectedSignature: '5a9347569f43e2eba196ab3403a699e74232127dc6ffe712fde0d052d6abf705291b019842b1137a3ba8198abf6925c8b79c7989cc8f78556ed36fa4ab3a2e08',
     txId: new Uint8Array([0xaa,0xd7,0x8a,0x13,0xb5,0x0a,0x01,0x4a,0x24,0x63,0x3c,0x7d,0x44,0xfd,0x8f,0x8d,0x18,0xf6,0x7b,0xbb,0x3f,0xa9,0xcb,0xce,0xdf,0x83,0x4a,0xc8,0x99,0x75,0x9d,0xcd]),
     txOutIndex: 1,
     coinValue: 12345678
@@ -17,7 +20,18 @@ const TEST_VECTORS = [
 ];
 
 let mkTest = (i) => {
-    const { redemptionKey, expectedAddress, expectedPublicKey, expectedSignature, txId, txOutIndex, coinValue } = TEST_VECTORS[i];
+    const {
+      iohkRedemptionPubKey,
+      expectedIohkRedemptionAddress,
+      expectedIohkRedemptionInputTx,
+      redemptionKey,
+      expectedAddress,
+      expectedPublicKey,
+      expectedSignature,
+      txId,
+      txOutIndex,
+      coinValue
+    } = TEST_VECTORS[i];
     const cfg = CardanoCrypto.Config.defaultConfig();
 
     describe('Test ' + i, function() {
@@ -26,8 +40,12 @@ let mkTest = (i) => {
         });
 
         it('generates valid avvm tx from public', function () {
-          const a = CardanoCrypto.Redemption.redemptionPubKeyToAvvmTxOut('URVk8FxX6Ik9z-Cub09oOxMkp6FwNq27kJUXbjJnfsQ=', cfg.protocol_magic);
-          console.log(a);
+          const { result: { tx_id, address } } = CardanoCrypto.Redemption.redemptionPubKeyToAvvmTxOut(
+            Buffer.from(iohkRedemptionPubKey, 'base64'),
+            cfg.protocol_magic);
+          const addressStr = bs58.encode(Buffer.from(address));
+          expect(addressStr).equal(expectedIohkRedemptionAddress);
+          expect(tx_id).equal(expectedIohkRedemptionInputTx);
         });
 
         it('generates valid address from private', function() {

--- a/wallet-wasm/src/lib.rs
+++ b/wallet-wasm/src/lib.rs
@@ -1287,13 +1287,13 @@ pub extern "C" fn redemption_public_to_avvm_tx_out(
     protocol_magic: u32,
     output_ptr: *mut c_uchar,
 ) -> i32 {
-    let pub_key = unsafe {
+    let pub_key: redeem::PublicKey = unsafe {
         let slice: &[u8] = std::slice::from_raw_parts(public_ptr, redeem::PUBLICKEY_SIZE);
-        redeem::PublicKey::from_slice(slice).unwrap()
+        jrpc_try!(output_ptr, redeem::PublicKey::from_slice(slice))
     };
     let magic = cardano::config::ProtocolMagic::from(protocol_magic);
     let (tx, address) = tx::redeem_pubkey_to_txid(&pub_key, magic);
-    let address_bytes = cbor!(address).unwrap();
+    let address_bytes = jrpc_try!(output_ptr, cbor!(address));
     jrpc_ok!(output_ptr, RedemptionAvvmTxOutput {
         tx_id: tx,
         address: address_bytes

--- a/wallet-wasm/src/lib.rs
+++ b/wallet-wasm/src/lib.rs
@@ -803,7 +803,7 @@ impl serde::Serialize for Coin {
     where
         S: serde::Serializer,
     {
-        let v: u64 = *self.0;
+        let v: u64 = u64::from(self.0);
         serializer.serialize_str(&format!("{}", v))
     }
 }

--- a/wallet-wasm/src/lib.rs
+++ b/wallet-wasm/src/lib.rs
@@ -1274,6 +1274,32 @@ pub extern "C" fn redemption_private_to_address(
     return address_bytes.len() as u32;
 }
 
+
+#[derive(Serialize, Deserialize, Debug)]
+struct RedemptionAvvmTxOutput {
+    tx_id: tx::TxId,
+    address: Vec<u8>,
+}
+
+#[no_mangle]
+pub extern "C" fn redemption_public_to_avvm_tx_out(
+    public_ptr: *const c_uchar,
+    protocol_magic: u32,
+    output_ptr: *mut c_uchar,
+) -> i32 {
+    let pub_key = unsafe {
+        let slice: &[u8] = std::slice::from_raw_parts(public_ptr, redeem::PUBLICKEY_SIZE);
+        redeem::PublicKey::from_slice(slice).unwrap()
+    };
+    let magic = cardano::config::ProtocolMagic::from(protocol_magic);
+    let (tx, address) = tx::redeem_pubkey_to_txid(&pub_key, magic);
+    let address_bytes = cbor!(address).unwrap();
+    jrpc_ok!(output_ptr, RedemptionAvvmTxOutput {
+        tx_id: tx,
+        address: address_bytes
+    })
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 struct WalletRedeemInput {
     protocol_magic: cardano::config::ProtocolMagic,


### PR DESCRIPTION
This feature is required to convert all avvm keys from the genesis block into transaction outputs.
1. Implemented `redemption_public_to_avvm_tx_out` in Rust
2. Implemented `redemptionPubKeyToAvvmTxOut` connector in JS
3. Implemented new test and fixed previous tests

For new test used actual publicly known IOHK redemption public key from the genesis and compared with the actual known address: `Ae2tdPwUPEZKQuZh2UndEoTKEakMYHGNjJVYmNZgJk2qqgHouxDsA5oT83n `.

Also fixed line in Rust where `Coin` were dereferences, since latest `rust-cardano` doesn't do it anymore.