### PR TITLE
add restore from daedalus master key

### DIFF
--- a/js/Wallet.js
+++ b/js/Wallet.js
@@ -54,6 +54,27 @@ export const fromMasterKey = (module, xprv) => {
     return JSON.parse(output_str);
 };
 
+/**
+ * Create a Daedalus wallet object from the given seed.
+ *
+ * @param module - the WASM module that is used for crypto operations
+ * @param xprv   - the 96 bytes master key
+ * @returns {*}  - a wallet object (JSON object)
+ */
+export const fromDaedalusMasterKey = (module, xprv) => {
+    const bufinput  = newArray(module, xprv);
+    const bufoutput = newArray0(module, MAX_OUTPUT_SIZE);
+
+    let rsz = module.xwallet_create_daedalus_master_key(bufinput, bufoutput);
+    let output_array = copyArray(module, bufoutput, rsz);
+
+    module.dealloc(bufoutput);
+    module.dealloc(bufinput);
+
+    let output_str = iconv.decode(Buffer.from(output_array), 'utf8');
+    return JSON.parse(output_str);
+};
+
 
 /**
  * Create a wallet object from the given seed.
@@ -309,6 +330,7 @@ export const checkAddress = (module, address) => {
 export default {
   fromSeed: apply(fromSeed, RustModule),
   fromMasterKey: apply(fromMasterKey, RustModule),
+  fromDaedalusMasterKey: apply(fromDaedalusMasterKey, RustModule),
   fromDaedalusMnemonic: apply(fromDaedalusMnemonic, RustModule),
   newAccount: apply(newAccount, RustModule),
   generateAddresses: apply(generateAddresses, RustModule),

--- a/wallet-wasm/src/lib.rs
+++ b/wallet-wasm/src/lib.rs
@@ -794,6 +794,27 @@ pub extern "C" fn xwallet_create_daedalus_mnemonic(
     jrpc_ok!(output_ptr, wallet)
 }
 
+#[no_mangle]
+pub extern "C" fn xwallet_create_daedalus_master_key(
+    input_ptr: *const c_uchar,
+    output_ptr: *mut c_uchar,
+) -> i32 {
+    let xprv = unsafe { read_xprv(input_ptr) };
+
+    let derivation_scheme = hdwallet::DerivationScheme::V1;
+    let selection_policy = SelectionPolicy::FirstMatchFirst;
+    let config = Config::default();
+
+    let wallet = DaedalusWallet {
+        root_cached_key: xprv,
+        config: config,
+        selection_policy: selection_policy,
+        derivation_scheme: derivation_scheme,
+    };
+
+    jrpc_ok!(output_ptr, wallet)
+}
+
 // TODO: write custom Serialize and Deserialize with String serialisation
 #[derive(PartialEq, Eq, Debug)]
 pub struct Coin(coin::Coin);


### PR DESCRIPTION
We had the two following existing functions:

1) Restoring V1 wallet from mnemonic
1) Restoring V2 wallet from master key

I joined the two together to make a new function "restoring V1 wallet from master key"

This is useful because it allows Daedalus users who forgot their mnemonic but remember their password to recover their wallet