### PR TITLE
Fix TextEncoder/TextDecoder issue issue

### DIFF
--- a/cardano-wallet/package.json
+++ b/cardano-wallet/package.json
@@ -4,11 +4,11 @@
         "serve": "webpack-dev-server"
     },
     "devDependencies": {
-        "text-encoding": "^0.7.0",
         "html-webpack-plugin": "^3.2.0",
         "webpack": "^4.11.1",
         "webpack-cli": "^3.1.1",
-        "webpack-dev-server": "^3.1.0"
+        "webpack-dev-server": "^3.1.0",
+        "text-encoder": "0.0.4"
     },
     "dependencies": {
         "cardano-wallet": "file:pkg"

--- a/cardano-wallet/tests/index.js
+++ b/cardano-wallet/tests/index.js
@@ -3,6 +3,13 @@
 // will work here one day as well!
 const Wallet = import('cardano-wallet');
 
+import { TextEncoder, TextDecoder } from 'text-encoder';
+
+// patch missing functions
+var util = require('util');
+util.TextEncoder = TextEncoder;
+util.TextDecoder = TextDecoder;
+
 let RustWallet = null;
 
 Wallet

--- a/cardano-wallet/webpack.config.js
+++ b/cardano-wallet/webpack.config.js
@@ -13,8 +13,8 @@ module.exports = {
         // Have this example work in Edge which doesn't ship `TextEncoder` or
         // `TextDecoder` at this time.
         new webpack.ProvidePlugin({
-            TextDecoder: ['text-encoding', 'TextDecoder'],
-            TextEncoder: ['text-encoding', 'TextEncoder']
+            TextDecoder: ['text-encoder', 'TextDecoder'],
+            TextEncoder: ['text-encoder', 'TextEncoder']
         })
     ],
     mode: 'development'


### PR DESCRIPTION
Without this change, running `npm run webpack-dev-serve` will result in the following two errors:

```
TypeError: TextEncoder is not a constructor
TypeError: TextDecoder is not a constructor
```

This will not help you if you get the error `__webpack_require__(...).readFileSync is not a function`. For that one you need to build the wasm bindings in browser mode.