### PR TITLE
Add to_hex methods

### DIFF
--- a/cardano-wallet/package.json
+++ b/cardano-wallet/package.json
@@ -11,6 +11,7 @@
         "text-encoder": "0.0.4"
     },
     "dependencies": {
-        "cardano-wallet": "file:pkg"
+        "cardano-wallet": "file:pkg",
+        "crypto-random-string": "1.0.0"
     }
 }

--- a/cardano-wallet/src/lib.rs
+++ b/cardano-wallet/src/lib.rs
@@ -389,8 +389,8 @@ impl Bip44RootPrivateKey {
         }
     }
 
-    pub fn to_hex(&self) -> String {
-        self.key.to_hex()
+    pub fn key(&self) -> PrivateKey {
+        self.key.clone()
     }
 }
 
@@ -419,8 +419,8 @@ impl Bip44AccountPrivate {
             .derive(self.derivation_scheme, index.0)
     }
 
-    pub fn to_hex(&self) -> String {
-        self.key.to_hex()
+    pub fn key(&self) -> PrivateKey {
+        self.key.clone()
     }
 }
 
@@ -447,8 +447,8 @@ impl Bip44AccountPublic {
             .derive(self.derivation_scheme, index.0)
     }
 
-    pub fn to_hex(&self) -> String {
-        self.key.to_hex()
+    pub fn key(&self) -> PublicKey {
+        self.key.clone()
     }
 }
 

--- a/cardano-wallet/src/lib.rs
+++ b/cardano-wallet/src/lib.rs
@@ -388,6 +388,10 @@ impl Bip44RootPrivateKey {
             derivation_scheme: self.derivation_scheme,
         }
     }
+
+    pub fn to_hex(&self) -> String {
+        self.key.to_hex()
+    }
 }
 
 #[wasm_bindgen]
@@ -414,6 +418,10 @@ impl Bip44AccountPrivate {
             .derive(self.derivation_scheme, if internal { 1 } else { 0 })
             .derive(self.derivation_scheme, index.0)
     }
+
+    pub fn to_hex(&self) -> String {
+        self.key.to_hex()
+    }
 }
 
 #[wasm_bindgen]
@@ -437,6 +445,10 @@ impl Bip44AccountPublic {
         self.key
             .derive(self.derivation_scheme, if internal { 1 } else { 0 })?
             .derive(self.derivation_scheme, index.0)
+    }
+
+    pub fn to_hex(&self) -> String {
+        self.key.to_hex()
     }
 }
 

--- a/cardano-wallet/tests/index.js
+++ b/cardano-wallet/tests/index.js
@@ -23,14 +23,15 @@ Wallet
 
     let entropy = Wallet.Entropy.from_english_mnemonics(MNEMONICS);
     let wallet = Wallet.Bip44RootPrivateKey.recover(entropy, MNEMONIC_PASSWORD);
-    console.log('master key: ' + wallet.to_hex());
+    const master_key =  wallet.key().to_hex();
+    console.log('master key: ' + master_key);
 
     // encrypt / decrypt example
     {
       const encoder = new TextEncoder();
       const salt = Buffer.from(cryptoRandomString(2 * 32), 'hex');
       const nonce = Buffer.from(cryptoRandomString(2 * 12), 'hex');
-      const encoded_key = new TextEncoder().encode(wallet.to_hex());
+      const encoded_key = new TextEncoder().encode(master_key);
       const encrypted_key = Wallet.password_encrypt(SPENDING_PASSWORD, salt, nonce, encoded_key);
       console.log('encrypted master key: ' + Buffer.from(encrypted_key).toString('hex'));
 
@@ -40,9 +41,9 @@ Wallet
     }
 
     let account = wallet.bip44_account(Wallet.AccountIndex.new(0 | 0x80000000));
-    console.log('account private ' + account.to_hex());
+    console.log('account private ' + account.key().to_hex());
     let account_public = account.public();
-    console.log('account public ' + account_public.to_hex());
+    console.log('account public ' + account_public.key().to_hex());
 
     let key_prv = account.address_key(false, Wallet.AddressKeyIndex.new(0));
     console.log('address public ' + key_prv.to_hex());

--- a/cardano-wallet/tests/index.js
+++ b/cardano-wallet/tests/index.js
@@ -22,11 +22,17 @@ Wallet
     let entropy = Wallet.Entropy.from_english_mnemonics(MNEMONICS);
     let wallet = Wallet.Bip44RootPrivateKey.recover(entropy, PASSWORD);
 
+    console.log('master key: ' + wallet.to_hex());
+
     let account = wallet.bip44_account(Wallet.AccountIndex.new(0 | 0x80000000));
+    console.log('account private ' + account.to_hex());
     let account_public = account.public();
+    console.log('account public ' + account_public.to_hex());
 
     let key_prv = account.address_key(false, Wallet.AddressKeyIndex.new(0));
+    console.log('address public ' + key_prv.to_hex());
     let key_pub = account_public.address_key(false, Wallet.AddressKeyIndex.new(0));
+    console.log('address public ' + key_pub.to_hex());
 
     let address = key_pub.bootstrap_era_address(settings);
 


### PR DESCRIPTION
For Yoroi we need to store `Bip44AccountPublic` and the encrypted version of `Bip44RootPrivateKey` in localstorage for non-hardware wallets so I needed to add `to_hex` functions. I added it to `Bip44AccountPrivate` also just because it'd be strange if one of the account structs didn't have `to_hex` randomly.

I also added code to the test to show how to encrypt/decrypt the mnemonic.