### PR TITLE
Remove bad tx functions

### DIFF
--- a/cardano-wallet/src/lib.rs
+++ b/cardano-wallet/src/lib.rs
@@ -776,10 +776,6 @@ impl Transaction {
         let bytes = cbor!(&self.0).map_err(|e| JsValue::from_str(&format! {"{:?}", e}))?;
         Ok(util::hex::encode(&bytes))
     }
-    pub fn to_base58(&self) -> Result<String, JsValue> {
-        let bytes = cbor!(&self.0).map_err(|e| JsValue::from_str(&format! {"{:?}", e}))?;
-        Ok(util::base58::encode(&bytes))
-    }
 }
 
 /// a signed transaction, ready to be sent to the network.
@@ -796,10 +792,6 @@ impl SignedTransaction {
     pub fn to_hex(&self) -> Result<String, JsValue> {
         let bytes = cbor!(&self.0).map_err(|e| JsValue::from_str(&format! {"{:?}", e}))?;
         Ok(util::hex::encode(&bytes))
-    }
-    pub fn to_base58(&self) -> Result<String, JsValue> {
-        let bytes = cbor!(&self.0).map_err(|e| JsValue::from_str(&format! {"{:?}", e}))?;
-        Ok(util::base58::encode(&bytes))
     }
 }
 


### PR DESCRIPTION
As we discussed, base58 doesn't make sense for these types. Base64 might be convenient to add because that's what we use in Yoroi but right now we construct base64 from converting the output of `to_hex` so it's not that big of a deal either.