### PR TITLE
Add signing tx with redemption key & External Key

### DIFF
--- a/cardano-wallet/src/lib.rs
+++ b/cardano-wallet/src/lib.rs
@@ -951,6 +951,21 @@ impl TransactionFinalized {
             .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
     }
 
+    pub fn sign_redeemption(
+        &mut self,
+        blockchain_settings: &BlockchainSettings,
+        key: &PrivateRedeemKey,
+    ) -> Result<(), JsValue> {
+        let signature = tx::TxInWitness::new_redeem_pk(
+            blockchain_settings.protocol_magic,
+            &key.0,
+            &self.tx_id
+        );
+        self.finalized
+            .add_witness(signature)
+            .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
+    }
+
     pub fn finalize(self) -> Result<SignedTransaction, JsValue> {
         self.finalized
             .make_txaux()

--- a/cardano-wallet/src/lib.rs
+++ b/cardano-wallet/src/lib.rs
@@ -309,6 +309,21 @@ impl Signature {
     }
 }
 
+#[wasm_bindgen]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransactionSignature(hdwallet::Signature<(tx::Tx)>);
+#[wasm_bindgen]
+impl TransactionSignature {
+    pub fn from_hex(hex: &str) -> Result<TransactionSignature, JsValue> {
+        hdwallet::Signature::from_hex(hex)
+            .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
+            .map(TransactionSignature)
+    }
+    pub fn to_hex(&self) -> String {
+        format!("{}", self.0)
+    }
+}
+
 /* ************************************************************************* *
  *                     BIP44 style Wallet (Icarus/Yoroi/Rust)                *
  * ************************************************************************* *
@@ -941,13 +956,13 @@ impl TransactionFinalized {
         blockchain_settings: &BlockchainSettings,
         key: &PrivateKey,
     ) -> Result<(), JsValue> {
-        let signature = tx::TxInWitness::new_extended_pk(
+        let witness = tx::TxInWitness::new_extended_pk(
             blockchain_settings.protocol_magic,
             &key.0,
             &self.tx_id,
         );
         self.finalized
-            .add_witness(signature)
+            .add_witness(witness)
             .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
     }
 
@@ -956,13 +971,29 @@ impl TransactionFinalized {
         blockchain_settings: &BlockchainSettings,
         key: &PrivateRedeemKey,
     ) -> Result<(), JsValue> {
-        let signature = tx::TxInWitness::new_redeem_pk(
+        let witness = tx::TxInWitness::new_redeem_pk(
             blockchain_settings.protocol_magic,
             &key.0,
             &self.tx_id
         );
         self.finalized
-            .add_witness(signature)
+            .add_witness(witness)
+            .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
+    }
+
+    /// used to add signatures created by hardware wallets where we don't have access
+    /// to the private key
+    pub fn from_external(
+        &mut self,
+        key: &PublicKey,
+        signature: &TransactionSignature,
+    ) -> Result<(), JsValue> {
+        let witness = tx::TxInWitness::PkWitness(
+            key.0.clone(),
+            signature.0.clone()
+        );
+        self.finalized
+            .add_witness(witness)
             .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
     }
 

--- a/cardano-wallet/src/lib.rs
+++ b/cardano-wallet/src/lib.rs
@@ -951,7 +951,7 @@ impl TransactionFinalized {
             .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
     }
 
-    pub fn sign_redeemption(
+    pub fn sign_redemption(
         &mut self,
         blockchain_settings: &BlockchainSettings,
         key: &PrivateRedeemKey,


### PR DESCRIPTION
looks like `TransactionFinalized` only allows you to sign with a `PrivateKey` but I need to sign with a `PrivateRedeemKey`

The added a new function to do this which mirrors the behavior of the old API
https://github.com/input-output-hk/js-cardano-wasm/blob/master/wallet-wasm/src/lib.rs#L1355

Also in the hardware wallet case, we do not have access to the private key at all. Instead, we receive the `PublicKey` and the `TransactionSignature` from the device.