### PR TITLE
Add missing id() function on TransactionFinalized 

### DIFF
--- a/cardano-wallet/src/lib.rs
+++ b/cardano-wallet/src/lib.rs
@@ -1021,6 +1021,10 @@ impl TransactionFinalized {
         }
     }
 
+    pub fn id(&self) -> TransactionId {
+        TransactionId(self.tx_id)
+    }
+
     /// sign the inputs of the transaction (i.e. unlock the funds the input are
     /// referring to).
     ///


### PR DESCRIPTION
After separating `Witness` into its own class, the signature for creating a witness is now

```
pub fn new_extended_key
        blockchain_settings: &BlockchainSettings,
        signing_key: &PrivateKey,
        transaction_id: &TransactionId,
) -> Witness {
```

So I needed to add a way to get `TransactionId` out of `TransactionFinalized `