### PR TITLE
Add Bip44 chain support and remove deprecated sign call

### DIFF
--- a/cardano-wallet/Cargo.toml
+++ b/cardano-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-wallet"
-version = "0.3.0"
+version = "1.0.0"
 authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>"]
 description = "Cardano Wallet, from rust to JS via Wasm"
 homepage = "https://github.com/input-output-hk/js-cardano-wasm#README.md"

--- a/cardano-wallet/README.md
+++ b/cardano-wallet/README.md
@@ -44,7 +44,8 @@ let account = wallet.bip44_account(Cardano.AccountIndex.new(0 | 0x80000000));
 let account_public = account.public();
 
 // create an address
-let key_pub = account_public.address_key(false, Cardano.AddressKeyIndex.new(0));
+let chain_pub = account_public.bip44_chain(false);
+let key_pub = chain_pub.address_key(Cardano.AddressKeyIndex.new(0));
 let address = key_pub.bootstrap_era_address(settings);
 
 console.log("Address m/bip44/ada/'0/0/0", address.to_base58());
@@ -120,7 +121,12 @@ You need to make sure:
 let transaction_finalizer = new Wallet.TransactionFinalized(transaction);
 
 for (let index = 0; index < inputs.length; index++) {
-    transaction_finalizer.sign(settings, key_prv);
+    const witness = Wallet.Witness.new_extended_key(
+        settings,
+        key_prv,
+        transaction_finalizer.id()
+    );
+    transaction_finalizer.add_witness(witness);
 }
 
 // at this stage the transaction is ready to be sent

--- a/cardano-wallet/tests/index.js
+++ b/cardano-wallet/tests/index.js
@@ -45,9 +45,11 @@ Wallet
     let account_public = account.public();
     console.log('account public ' + account_public.key().to_hex());
 
-    let key_prv = account.address_key(false, Wallet.AddressKeyIndex.new(0));
+    let chain_prv = account.bip44_chain(false);
+    let key_prv = chain_prv.address_key(Wallet.AddressKeyIndex.new(0));
     console.log('address public ' + key_prv.to_hex());
-    let key_pub = account_public.address_key(false, Wallet.AddressKeyIndex.new(0));
+    let chain_pub = account_public.bip44_chain(false);
+    let key_pub = chain_pub.address_key(Wallet.AddressKeyIndex.new(0));
     console.log('address public ' + key_pub.to_hex());
 
     let address = key_pub.bootstrap_era_address(settings);
@@ -105,7 +107,12 @@ Wallet
     console.log("transaction finalizer built", transaction_finalizer);
 
     for (let index = 0; index < inputs.length; index++) {
-      transaction_finalizer.sign(settings, key_prv);
+      const witness = Wallet.Witness.new_extended_key(
+        settings,
+        key_prv,
+        transaction_finalizer.id()
+      );
+      transaction_finalizer.add_witness(witness);
       console.log("signature ", index, "added");
 
     }


### PR DESCRIPTION
In Yoroi we will need in the future to actually be able to refer to the Bip44 chain as a type so I'm just putting this PR in advance.

I made this as a breaking change (therefore bumping the major version) and since it's a breaking change I figured I might as well remove the deprecated `sign` function.
