### PR TITLE
Make txs copyable

### DIFF
--- a/cardano-wallet/src/lib.rs
+++ b/cardano-wallet/src/lib.rs
@@ -867,7 +867,6 @@ impl TxOut {
 /// 2. sign the transaction on the other/thread/machines/cold-wallet...;
 ///
 #[wasm_bindgen]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Transaction(tx::Tx);
 #[wasm_bindgen]
 impl Transaction {
@@ -880,6 +879,7 @@ impl Transaction {
     pub fn from_json(value: JsValue) -> Result<Transaction, JsValue> {
         value
             .into_serde()
+            .map(Transaction)
             .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
     }
     pub fn clone(&self) -> Transaction {
@@ -893,7 +893,6 @@ impl Transaction {
 
 /// a signed transaction, ready to be sent to the network.
 #[wasm_bindgen]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct SignedTransaction(tx::TxAux);
 #[wasm_bindgen]
 impl SignedTransaction {
@@ -906,6 +905,7 @@ impl SignedTransaction {
     pub fn from_json(value: JsValue) -> Result<SignedTransaction, JsValue> {
         value
             .into_serde()
+            .map(SignedTransaction)
             .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
     }
     pub fn from_bytes(bytes: &[u8]) -> Result<SignedTransaction, JsValue> {


### PR DESCRIPTION
For Yoroi the Send screen allows the user to author a transaction. Once they've specified the receiver and the amount, they can press the "send" button to broadcast the transaction.

They way I would like this to work internally (currently it's a big hack job) is that the Send page creates a `Transaction` and when they press the "send" button it tries to create a `SignedTransaction`. The problem is that creating a `SignedTransaction` frees the original `Transaction` object so it's not easy to provide a fallback if a tx fails. The cleanest way to solve this is when you press the "send" button, it clones the transaction and tries to sign the clone. If signing fails, it falls back to the original `Transaction`.  

I also added `from_json` in here since probably this will be useful for unit tests once I finish this part of Yoroi refactoring.