### PR TITLE
Add daedalus master key export

### DIFF
--- a/cardano-wallet/Cargo.toml
+++ b/cardano-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-wallet"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>", "Sebastien Guillemot <sebastien@emurgo.io>"]
 description = "Cardano Wallet, from rust to JS via Wasm"
 homepage = "https://github.com/input-output-hk/js-cardano-wasm#README.md"

--- a/cardano-wallet/src/lib.rs
+++ b/cardano-wallet/src/lib.rs
@@ -550,6 +550,10 @@ impl DaedalusWallet {
         DaedalusWallet(key)
     }
 
+    pub fn master_key(&self) -> PrivateKey {
+        self.0.clone()
+    }
+
     pub fn recover(entropy: &Entropy) -> Result<DaedalusWallet, JsValue> {
         let entropy_bytes = cbor_event::Value::Bytes(Vec::from(entropy.0.as_ref()));
         let entropy_cbor =


### PR DESCRIPTION
This PR makes it easy to get the master key from a Daedalus mnemonic. I've had to do this fairly often myself also so it seems like it's a useful feature and very simple change.

Here is how you use it.

```
Wallet
  .then(Wallet => {
    const daedalusMnemonic = 'note park thrive ignore spare latin common balance clap soup school tiny';
    const daedalusEntropy = Wallet.Entropy.from_english_mnemonics(daedalusMnemonic);
    const daedalusWallet = Wallet.DaedalusWallet.recover(daedalusEntropy);
    console.log(daedalusWallet.master_key().to_hex());
  })
```