### PR TITLE
typo fix

### DIFF
--- a/js-example/psc-package.json
+++ b/js-example/psc-package.json
@@ -1,5 +1,5 @@
 {
-    "name": "Cardnoa-HdWallet",
+    "name": "Cardano-HdWallet",
     "set": "psc-0.10.1",
     "source": "https://github.com/purescript/package-sets.git",
     "depends": [


### PR DESCRIPTION
Small typo fix:
`Cardnoa` -> `Cardano`