### PR TITLE
Testnet address generation

### DIFF
--- a/cardano-wallet/src/lib.rs
+++ b/cardano-wallet/src/lib.rs
@@ -684,7 +684,7 @@ impl serde::Serialize for Coin {
     where
         S: serde::Serializer,
     {
-        let v: u64 = *self.0;
+        let v = u64::from(self.0);
         serializer.serialize_str(&format!("{}", v))
     }
 }
@@ -743,13 +743,13 @@ impl Coin {
     }
 
     pub fn ada(&self) -> u32 {
-        let v = *self.0 / 1_000_000;
+        let v = u64::from(self.0) / 1_000_000;
         assert!(v < 0xFFFF_FFFF);
         v as u32
     }
 
     pub fn lovelace(&self) -> u32 {
-        (*self.0 % 1_000_000) as u32
+        (u64::from(self.0) % 1_000_000) as u32
     }
 
     pub fn add(&self, other: &Coin) -> Result<Coin, JsValue> {


### PR DESCRIPTION
The motivation to change this part of the deprecated `wallet-wasm`
library was the simple introduction of testnet address support in
yoroi-mobile. The alternative is to migrate all of yoroi-mobile away to
use the new `cardano-wallet` module, but this would be significant work
in comparison and can be delayed. Directly adapting
`react-native-cardano` to use `cardano-wallet` was not feasible either
as the API is quite different and would be exceptionally awkward to try
and force into the `react-native-cardano` API that was built on top of
`wallet-wasm` with its API in mind.

Only `xwallet_account()` was changed, as the other function lacking
support for testnet, `wallet_public_to_address()` does not seem to be used
anywhere in `react-native-cardano`, which was the motivation for this change.
Changing `wallet_public_to_address()` would also be more difficult as it
requires a hard API change or an additional function to allow
overloading.

On the other hand, `xwallet_account()` supports a JSON API,
which conveniently allows us to be backwards compatible, as the absence
of the `protocol_magic` field will revert to the previous behavior of
default (mainnet) protocol magic.

Additionally, the `rust-cardano` dependency here was updated as verification of
testnet addresses was not working properly in the very old of `rust-cardano` that was used.