### PR TITLE
output signed tx in binary format

### DIFF
--- a/cardano-wallet/src/lib.rs
+++ b/cardano-wallet/src/lib.rs
@@ -921,6 +921,10 @@ impl SignedTransaction {
         let bytes = cbor!(&self.0).map_err(|e| JsValue::from_str(&format! {"{:?}", e}))?;
         Ok(util::hex::encode(&bytes))
     }
+    pub fn to_bytes(&self) -> Result<String, JsValue> {
+        let bytes = cbor!(&self.0).map_err(|e| JsValue::from_str(&format! {"{:?}", e}))?;
+        Ok(bytes)
+    }
 }
 
 /// This is the linear fee algorithm used buy the current cardano blockchain.


### PR DESCRIPTION
Added a new function to allow the output of a signed transaction in binary format