### PR TITLE
Add is_valid address function

### DIFF
--- a/cardano-wallet/Cargo.toml
+++ b/cardano-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-wallet"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>", "Sebastien Guillemot <sebastien@emurgo.io>"]
 description = "Cardano Wallet, from rust to JS via Wasm"
 homepage = "https://github.com/input-output-hk/js-cardano-wasm#README.md"

--- a/cardano-wallet/Cargo.toml
+++ b/cardano-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-wallet"
-version = "1.3.0"
+version = "1.2.1"
 authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>", "Sebastien Guillemot <sebastien@emurgo.io>"]
 description = "Cardano Wallet, from rust to JS via Wasm"
 homepage = "https://github.com/input-output-hk/js-cardano-wasm#README.md"

--- a/cardano-wallet/README.md
+++ b/cardano-wallet/README.md
@@ -134,3 +134,11 @@ const signed_transaction = transaction_finalizer.finalize();
 console.log("ready to send transaction: ", signed_transaction.to_hex());
 console.log(signed_transaction.to_json());
 ```
+
+# How to build (locally)
+
+```
+wasm-pack build --target browser
+npm install
+npm run serve
+```

--- a/cardano-wallet/src/lib.rs
+++ b/cardano-wallet/src/lib.rs
@@ -293,6 +293,14 @@ impl Address {
             .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
             .map(Address)
     }
+
+    pub fn is_valid(s: &str) -> bool {
+        use std::str::FromStr;
+        match address::ExtendedAddr::from_str(s) {
+            Ok(v) => true,
+            Err(err) => false,
+        }
+    }
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
In Shelley, we often have to do

```
if byron_address
  do X
else if shelley_address
  do Y
```

# Why we need a special function

The problem is that due to https://github.com/rustwasm/wasm-bindgen/issues/1963 returning a Result that represents an error on the Rust side actually causes stack space to be permanently lost.

This causes Yoroi to crash running out of stack space after some time.

To solve this, I introduce a new function called `is_valid` that instead returns a boolean.

You can tell this fix works based on the following:

```js
let err = null;
for (let j = 0; j < 100000; j++) {
  try {
    // uncommenting  will not cause a crash
    console.log(Wallet.Address.is_valid("asdf"));

    // uncommenting this will cause a crash due to lack of stack space
    // console.log(Wallet.Address.from_base58("a"));
  } catch (e) {
    if (err == null) {
      err = e;
      continue;
    }
    if (e === err) {
      continue;
    }
    console.log('iteration', j);
    throw e;
  }
}
```

# How to use this function

```js
// false
console.log(Wallet.Address.is_valid("asdf"));

// true
console.log(Wallet.Address.is_valid("Ae2tdPwUPEZAD1KmgTQ4zS6Q5s4VXWDXqB3ZmM1abQGoyrGN8qCsZyXc3vf"));

// true
console.log(Wallet.Address.is_valid("DdzFFzCqrht74dr7DYmiyCobGFQcfLCsHJCCM6nEBTztrsEk5kwv48EWKVMFU9pswAkLX9CUs4yVhVxqZ7xCVDX1TdatFwX5W39cohvm"));
```