### PR TITLE
Update Cargo.toml

### DIFF
--- a/cardano-wallet/Cargo.toml
+++ b/cardano-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-wallet"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>", "Sebastien Guillemot <sebastien@emurgo.io>"]
 description = "Cardano Wallet, from rust to JS via Wasm"
 homepage = "https://github.com/input-output-hk/js-cardano-wasm#README.md"


### PR DESCRIPTION
It seems

`cardano-wallet-browser` was updated correctly
`cardano-wallet` accidentally has the browser bindings instead of the nodejs bindings

Since you can't updating existing versions, I'm bumping the version number so we can resubmit (and maybe pull 1.2.1 from NPM?)